### PR TITLE
Fix broken message bug & Fix Makefile error & Add a sample client(On Linux kernel 5.3.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fastecho-objs := $(CFILES:.c=.o)
 
 
 all:
-	make -C $(KERNEL_DIR) SUBDIRS=$(BUILD_DIR) KBUILD_VERBOSE=$(VERBOSE) modules
+	make -C $(KERNEL_DIR) M=$(BUILD_DIR) KBUILD_VERBOSE=$(VERBOSE) modules
 
 clean:
 	rm -f *.o *.ko *.mod.c *.symvers *.order .fastecho*

--- a/echo_server.c
+++ b/echo_server.c
@@ -26,7 +26,7 @@ static int get_request(struct socket *sock, unsigned char *buf, size_t size){
   //get msg
   length = kernel_recvmsg(sock, &msg, &vec, size, size, msg.msg_flags);
 
-  printk(MODULE_NAME ": get request = %s\n", buf);
+  printk(MODULE_NAME ": get request = \"%s\" \n", buf);
 
   return length;
 }
@@ -49,7 +49,7 @@ static int send_request(struct socket *sock, unsigned char *buf, size_t size){
 
   printk(MODULE_NAME ": start send request.\n"); 
   
-  length = kernel_sendmsg(sock, &msg, &vec, 1, strlen(buf)-1);
+  length = kernel_sendmsg(sock, &msg, &vec, strlen(buf), strlen(buf));
   
   printk(MODULE_NAME ": send request = %s\n", buf);
 
@@ -71,6 +71,8 @@ static int echo_server_worker(void *arg){
     printk(KERN_ERR MODULE_NAME ": kmalloc error....\n");
     return -1;
   }
+
+  memset(buf, 0, BUF_SIZE);
 
   while(!kthread_should_stop()){
     res = get_request(sock, buf, BUF_SIZE-1);
@@ -108,7 +110,7 @@ int echo_server_daemon(void *arg){
   int error;
 
   //init
-  param = (struct echo_server_status *)arg;
+  param = (struct echo_server_param *)arg;
   allow_signal(SIGKILL);
   allow_signal(SIGTERM);
 

--- a/tcp_client.py
+++ b/tcp_client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#This code was written with reference to this page: http://rabbitfoot141.hatenablog.com/entry/2018/01/22/111550
 
 import socket
 

--- a/tcp_client.py
+++ b/tcp_client.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import socket
+
+target = "localhost"
+port = 8888
+message = "hello,world!"
+
+#using IPv4 and TCP/IP
+client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+#connecting
+client_socket.connect((target, port))
+
+#data send
+client_socket.send(message.encode('utf-8'))
+
+#get data
+response_data = client_socket.recv(4096) 
+
+print(response_data.decode(encoding='utf-8'))


### PR DESCRIPTION
Fix 1 bug and 1 error on Linux kernel 5.3.5.
# Fix broken message bug

## add a memset()
Now, there is a bug that some characters is added to a send message. This bug occur caused by the memory allocated by kmalloc() is not cleared to 0. So, I added memset() to clear to 0 the memory after the kmalloc().

## fix argument of kernel_sendmsg
About Line 52: `kernel_sendmsg(sock, &msg, &vec, 1, strlen(buf)-1)`, each argument 4 and 5 of kernel_sendmsg() should be length of message. So fix it to `kernel_sendmsg(sock, &msg, &vec, strlen(buf), strlen(buf))`.

# Fix Makefile error 
When I execute make, this WARNING raised.
```
Makefile:213: ================= WARNING ================
Makefile:214: 'SUBDIRS' will be removed after Linux 5.3
Makefile:215: 
Makefile:216: If you are building an individual subdirectory
Makefile:217: in the kernel tree, you can do like this:
Makefile:218: $ make path/to/dir/you/want/to/build/
Makefile:219: (Do not forget the trailing slash)
Makefile:220: 
Makefile:221: If you are building an external module,
Makefile:222: Please use 'M=' or 'KBUILD_EXTMOD' instead
Makefile:223: ==========================================
```
According to this WARNING, fixed 'SUBDIR' to 'M='.

# Add a sample client
Add a sample tcp client written in Python3.